### PR TITLE
AMRNAV-6824 Diagnostic warnings about high CPU always appeared on AMR24

### DIFF
--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
@@ -52,7 +52,7 @@ from rclpy.node import Node
 
 class CpuTask(DiagnosticTask):
 
-    def __init__(self, warning_percentage=90, window=1, warn_multiple = 3, error_multiple = 5):
+    def __init__(self, warning_percentage=90, window=1, warn_multiple=3, error_multiple=5):
         DiagnosticTask.__init__(self, 'CPU Information')
 
         self._warning_percentage = int(warning_percentage)

--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
@@ -35,16 +35,16 @@
 
 # \author Rein Appeldoorn
 
-from collections import deque
+import os
 import socket
 import traceback
 
-from diagnostic_msgs.msg import DiagnosticStatus
+from collections import deque
 
-from diagnostic_updater import DiagnosticTask, Updater
-
-import os
 import psutil
+
+from diagnostic_msgs.msg import DiagnosticStatusWrapper
+from diagnostic_updater import DiagnosticTask, Updater
 
 import rclpy
 from rclpy.node import Node
@@ -52,11 +52,17 @@ from rclpy.node import Node
 
 class CpuTask(DiagnosticTask):
 
-    def __init__(self, warning_percentage=90, window=1):
+    def __init__(self, warning_percentage=90, window=1, warn_multiple = 3, error_multiple = 5):
         DiagnosticTask.__init__(self, 'CPU Information')
 
         self._warning_percentage = int(warning_percentage)
         self._readings = deque(maxlen=window)
+        self._warn_multiple = int(warn_multiple)
+        self._error_multiple = int(error_multiple)
+
+        num_cpus = os.cpu_count()
+        self._warn_threshold = warn_multiple * num_cpus
+        self._error_threshold = error_multiple * num_cpus
 
     def _get_average_reading(self):
         def avg(lst):
@@ -75,13 +81,17 @@ class CpuTask(DiagnosticTask):
         for idx, cpu_percentage in enumerate(cpu_percentages):
             stat.add(f'CPU {idx} Load', f'{cpu_percentage:.2f}')
 
-        num_cpus = os.cpu_count()
         load1, load5, load15 = os.getloadavg()
-        threshold = 3 * num_cpus
-
-        if load1 > threshold:
+        stat.add('System load average 1 min', f'{load1:.2f}')
+        stat.add('System load average 5 min', f'{load5:.2f}')
+        stat.add('System load average 15 min', f'{load15:.2f}')
+        
+        if load1 > self._error_threshold:
+            stat.summary(DiagnosticStatus.ERROR,
+                         f'System load exceeds {self._error_threshold} percent')
+        elif load1 > self._warn_threshold:
             stat.summary(DiagnosticStatus.WARN,
-                         f'System load exceeds {threshold} percent')
+                         f'System load exceeds {self._warn_threshold} percent')
         else:
             stat.summary(DiagnosticStatus.OK,
                          f'CPU Average {cpu_average:.2f} percent')
@@ -98,15 +108,19 @@ def get_cpu_diagnostics_node() -> Node:
     # Declare and get parameters
     node.declare_parameter('warning_percentage', 90)
     node.declare_parameter('window', 1)
+    node.declare_parameter('warn_multiple', 3)
+    node.declare_parameter('error_multiple', 5)
 
     warning_percentage = node.get_parameter(
         'warning_percentage').get_parameter_value().integer_value
     window = node.get_parameter('window').get_parameter_value().integer_value
+    warn_multiple = node.get_parameter('warn_multiple').get_parameter_value().integer_value
+    error_multiple = node.get_parameter('error_multiple').get_parameter_value().integer_value
 
     # Create diagnostic updater with default updater rate of 1 hz
     updater = Updater(node)
     updater.setHardwareID(hostname)
-    updater.add(CpuTask(warning_percentage=warning_percentage, window=window))
+    updater.add(CpuTask(warning_percentage=warning_percentage, window=window, warn_multiple=warn_multiple, error_multiple=error_multiple))
 
     return node
 

--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
@@ -43,6 +43,7 @@ from diagnostic_msgs.msg import DiagnosticStatus
 
 from diagnostic_updater import DiagnosticTask, Updater
 
+import os
 import psutil
 
 import rclpy
@@ -71,15 +72,16 @@ class CpuTask(DiagnosticTask):
 
         stat.add('CPU Load Average', f'{cpu_average:.2f}')
 
-        warn = False
         for idx, cpu_percentage in enumerate(cpu_percentages):
             stat.add(f'CPU {idx} Load', f'{cpu_percentage:.2f}')
-            if cpu_percentage > self._warning_percentage:
-                warn = True
 
-        if warn:
+        num_cpus = os.cpu_count()
+        load1, load5, load15 = os.getloadavg()
+        threshold = 3 * num_cpus
+
+        if load1 > threshold:
             stat.summary(DiagnosticStatus.WARN,
-                         f'At least one CPU exceeds {self._warning_percentage} percent')
+                         f'System load exceeds {threshold} percent')
         else:
             stat.summary(DiagnosticStatus.OK,
                          f'CPU Average {cpu_average:.2f} percent')


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column               |
| --------------------- | ----------------------------------------- |
| Platform tested on    |  Gazebo / AMR |
| Related documentation |                                           |
| Ticket                |  https://lvserv01.logivations.com/browse/AMRNAV-6824 |

### Description of contribution

**Reason for change:**

Diagnostic warnings about high CPU always appeared 
Please check if this warning shows actual information


**Changes in this PR:**

- if system load exceeds 3*num cpus then send warning to w2mo
- added two parameters, with error_multiple (default 5) and warn_multiple (default 3)
- added the load1, load 5, load15 to `stat`

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in tracking.properties
* If breaking change - was it added to https://coda.io/d/Autonomous-Mobile-Robot_da82dg_s4hc/Release-notes_suOpf?search=#_luotl ?
-->

**Result:**
No unnecessary warnings


